### PR TITLE
Change behaviour when searching for notes with empty characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION := $(shell git describe --tags --abbrev=0 | awk -F "." '{sub("v","", $$1); printf "%s.%s.%s\n",$$1,$$2,$$3+1}')
 
 BINARY := fcqs-cli
-GO_FILES := $(shell find . -type f -name '*.go' ! -name '*test*') go.* shell.bash
+GO_FILES := $(shell find . -type f -name '*.go') go.* shell.bash
 GOCOVERDIR := coverdir
 
 $(BINARY): $(GO_FILES)

--- a/fcqs.go
+++ b/fcqs.go
@@ -61,6 +61,10 @@ func WriteTitles(w io.Writer, r io.Reader) {
 // WriteContents writes the contents of the note.
 func WriteContents(w io.Writer, r io.Reader, title string) {
 	title = strings.Trim(title, " ")
+	if title == "" {
+		return
+	}
+
 	state := Normal
 
 	_, isNoTitle := os.LookupEnv("FCQS_CONTENTS_NO_TITLE")

--- a/fcqs.go
+++ b/fcqs.go
@@ -147,8 +147,11 @@ func isSearchedTitleLine(line string, title string) bool {
 
 // WriteFirstURL writes the first URL in the contents of the note.
 func WriteFirstURL(w io.Writer, r io.Reader, title string) {
-	var buf bytes.Buffer
+	if isEmptyTrimmedTitle(title) {
+		return
+	}
 
+	var buf bytes.Buffer
 	WriteContents(&buf, r, title)
 
 	rxStrict := xurls.Strict()
@@ -161,10 +164,13 @@ func WriteFirstURL(w io.Writer, r io.Reader, title string) {
 
 // WriteFirstCmdLineBlock writes the first command-line block in the contents of the note.
 func WriteFirstCmdLineBlock(w io.Writer, r io.Reader, title string) {
-	var buf bytes.Buffer
+	if isEmptyTrimmedTitle(title) {
+		return
+	}
 
 	state := Normal
 
+	var buf bytes.Buffer
 	WriteContents(&buf, r, title)
 	scanner := bufio.NewScanner(&buf)
 
@@ -206,6 +212,10 @@ func isShellCodeBlockBegin(line string) bool {
 
 // WriteNoteLocation writes the file name and line number of the note.
 func WriteNoteLocation(w io.Writer, file *os.File, title string) {
+	if isEmptyTrimmedTitle(title) {
+		return
+	}
+
 	c := 0
 	scanner := bufio.NewScanner(file)
 
@@ -234,4 +244,9 @@ func GetNotesFileName() (string, error) {
 
 	fileName = filepath.Join(home, DefaultNotesFile)
 	return fileName, nil
+}
+
+// isEmptyTrimmedTitle determines if trimmed tile is empty.
+func isEmptyTrimmedTitle(title string) bool {
+	return strings.Trim(title, " ") == ""
 }

--- a/fcqs_test.go
+++ b/fcqs_test.go
@@ -42,7 +42,6 @@ func TestWriteContents(t *testing.T) {
 		{"#   Spaces before the title are ignored\n", "contents\n"},
 		{"# Headings in fenced code blocks are ignored\n", "```\n" + "# fenced heading\n" + "```\n"},
 		{"# There can be no blank line", "contents\n"},
-		{"#\n", "no title contents are combined into one.\n\n" + "#  \n\n" + "title is only spaces\n"},
 		{"# Titles without a space after the # are not recognized\n", "#no_space_title\n\n" + "contents\n\n" +
 			"  # Titles with spaces before the # are not recognized\n\n" + "contents\n"},
 		{"# URL\n", "fcqs: http://github.com/yendo/fcqs/\n" + "github: http://github.com/\n"},
@@ -95,6 +94,14 @@ func TestWriteNoContents(t *testing.T) {
 		desc  string
 		title string
 	}{
+		{
+			desc:  "Empty titles are recognized as title, but do not output the contents.",
+			title: "#",
+		},
+		{
+			desc:  "Titles only spaces are recognized as title, but do not output the contents.",
+			title: "#  ",
+		},
 		{
 			desc:  "Titles without a space after the `#` are not recognized as title",
 			title: "#no_space_title",

--- a/fcqs_test.go
+++ b/fcqs_test.go
@@ -128,13 +128,21 @@ func TestWriteNoContents(t *testing.T) {
 
 func TestWriteFirstURL(t *testing.T) {
 	t.Parallel()
-
-	var buf bytes.Buffer
 	file := test.OpenTestNotesFile(t, test.TestNotesFile)
 
-	fcqs.WriteFirstURL(&buf, file, "URL")
+	t.Run("title is valid", func(t *testing.T) {
+		var buf bytes.Buffer
+		fcqs.WriteFirstURL(&buf, file, "URL")
 
-	assert.Equal(t, "http://github.com/yendo/fcqs/\n", buf.String())
+		assert.Equal(t, "http://github.com/yendo/fcqs/\n", buf.String())
+	})
+
+	t.Run("title is empty", func(t *testing.T) {
+		var buf bytes.Buffer
+		fcqs.WriteFirstURL(&buf, file, "")
+
+		assert.Empty(t, buf.String())
+	})
 }
 
 func TestWriteFirstCmdLine(t *testing.T) {
@@ -160,6 +168,7 @@ func TestWriteFirstCmdLine(t *testing.T) {
 		{"go", false},
 		{"no identifier", false},
 		{"other identifier", false},
+		{"", false},
 	}
 
 	for _, tc := range tests {
@@ -179,13 +188,21 @@ func TestWriteFirstCmdLine(t *testing.T) {
 
 func TestWriteNoteLocation(t *testing.T) {
 	t.Parallel()
-
-	var buf bytes.Buffer
-
 	testFile := test.OpenTestNotesFile(t, test.TestLocationFile)
-	fcqs.WriteNoteLocation(&buf, testFile, "5th Line")
 
-	assert.Equal(t, fmt.Sprintf("%q 5\n", testFile.Name()), buf.String())
+	t.Run("title is valid", func(t *testing.T) {
+		var buf bytes.Buffer
+		fcqs.WriteNoteLocation(&buf, testFile, "5th Line")
+
+		assert.Equal(t, fmt.Sprintf("%q 5\n", testFile.Name()), buf.String())
+	})
+
+	t.Run("title is empty", func(t *testing.T) {
+		var buf bytes.Buffer
+		fcqs.WriteNoteLocation(&buf, testFile, "")
+
+		assert.Empty(t, buf.String())
+	})
 }
 
 func TestGetFcqsFile(t *testing.T) {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -50,14 +50,29 @@ func TestCmdSuccess(t *testing.T) {
 			stdout:  "http://github.com/yendo/fcqs/\n",
 		},
 		{
+			title:   "with url flag and an empty arg",
+			options: []string{"-u", ""},
+			stdout:  "",
+		},
+		{
 			title:   "with cmd flag and an arg",
 			options: []string{"-c", "command-line"},
 			stdout:  "ls -l | nl\n",
 		},
 		{
+			title:   "with cmd flag and an empty arg",
+			options: []string{"-c", ""},
+			stdout:  "",
+		},
+		{
 			title:   "with location flag and an arg",
 			options: []string{"-l", "title"},
 			stdout:  fmt.Sprintf("%q 1\n", TestNotesFile),
+		},
+		{
+			title:   "with location flag and an empty arg",
+			options: []string{"-l", ""},
+			stdout:  "",
 		},
 		{
 			title:   "without args",

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -65,6 +65,16 @@ func TestCmdSuccess(t *testing.T) {
 			stdout:  GetExpectedTitles(),
 		},
 		{
+			title:   "with an empty arg",
+			options: []string{""},
+			stdout:  "",
+		},
+		{
+			title:   "with an arg of spaces",
+			options: []string{"  "},
+			stdout:  "",
+		},
+		{
 			title:   "with an arg",
 			options: []string{"There can be no blank line"},
 			stdout:  "# There can be no blank line\ncontents\n", // next line is only "#".

--- a/test/testdata/test_fcnotes.md
+++ b/test/testdata/test_fcnotes.md
@@ -57,7 +57,7 @@ contents
 contents
 #
 
-no title contents are combined into one.
+no title contents are not output.
 
 #  
 


### PR DESCRIPTION
When searching for notes with empty characters, all notes with empty titles are output. However, if there are many empty notes, a large number of notes are unintentionally output. Change the specification so that a search with empty characters returns nothing.

Fix #40 