### PR TITLE
Add support for multi notes files

### DIFF
--- a/cmd/fcqs-cli/main.go
+++ b/cmd/fcqs-cli/main.go
@@ -45,11 +45,19 @@ func run(w io.Writer) error {
 		return fmt.Errorf("notes file name: %w", err)
 	}
 
-	file, err := os.Open(fileName)
-	if err != nil {
-		return fmt.Errorf("notes file: %w", err)
+	var readers []io.Reader
+	var files []*os.File
+	for _, v := range fileName {
+		file, err := os.Open(v)
+		if err != nil {
+			return fmt.Errorf("notes file: %w", err)
+		}
+		readers = append(readers, file)
+		files = append(files, file)
+		defer file.Close()
 	}
-	defer file.Close()
+
+	file := io.MultiReader(readers...)
 
 	switch len(args) {
 	case 0:
@@ -70,7 +78,7 @@ func run(w io.Writer) error {
 		case *showCmd:
 			err = fcqs.WriteFirstCmdLineBlock(w, file, title)
 		case *showLoc:
-			err = fcqs.WriteNoteLocation(w, file, title)
+			err = fcqs.WriteNoteLocation(w, files, title)
 		default:
 			err = fcqs.WriteContents(w, file, title, *noTitle)
 		}

--- a/cmd/fcqs-cli/main_test.go
+++ b/cmd/fcqs-cli/main_test.go
@@ -122,7 +122,7 @@ func TestRunFail(t *testing.T) {
 }
 
 func TestRunMultiFiles(t *testing.T) {
-	t.Setenv("FCQS_NOTES_FILE", test.FullPath(test.LocationFile)+":"+test.FullPath(test.LocationExtraFile))
+	t.Setenv("FCQS_NOTES_FILE", test.FullPath(test.LocationFile)+test.FileSeparator()+test.FullPath(test.LocationExtraFile))
 
 	t.Run("show titles", func(t *testing.T) {
 		setOSArgs(t, []string{"fcqs-cli"})
@@ -156,7 +156,7 @@ func TestRunMultiFiles(t *testing.T) {
 	})
 
 	t.Run("file error", func(t *testing.T) {
-		t.Setenv("FCQS_NOTES_FILE", test.FullPath(test.LocationFile)+":"+"invalid_file")
+		t.Setenv("FCQS_NOTES_FILE", test.FullPath(test.LocationFile)+test.FileSeparator()+"invalid_file")
 		setOSArgs(t, []string{"fcqs-cli"})
 
 		var buf bytes.Buffer

--- a/cmd/fcqs-cli/main_test.go
+++ b/cmd/fcqs-cli/main_test.go
@@ -121,6 +121,52 @@ func TestRunFail(t *testing.T) {
 	})
 }
 
+func TestRunMultiFiles(t *testing.T) {
+	t.Setenv("FCQS_NOTES_FILE", test.FullPath(test.LocationFile)+":"+test.FullPath(test.LocationExtraFile))
+
+	t.Run("show titles", func(t *testing.T) {
+		setOSArgs(t, []string{"fcqs-cli"})
+
+		var buf bytes.Buffer
+		err := run(&buf)
+
+		require.NoError(t, err)
+		assert.Equal(t, "location test data\n5th Line\nother 5th Line\n9th Line\n", buf.String())
+	})
+
+	t.Run("show contents", func(t *testing.T) {
+		setOSArgs(t, []string{"fcqs-cli", "9th Line"})
+
+		var buf bytes.Buffer
+		err := run(&buf)
+
+		require.NoError(t, err)
+		assert.Equal(t, "# 9th Line\n\nDo not chang the 9th line.\n", buf.String())
+	})
+
+	t.Run("show location", func(t *testing.T) {
+		setOSArgs(t, []string{"fcqs-cli", "-l", "9th Line"})
+		setCommandLineFlag(t, "location")
+
+		var buf bytes.Buffer
+		err := run(&buf)
+
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("%q 9\n", test.FullPath(test.LocationExtraFile)), buf.String())
+	})
+
+	t.Run("file error", func(t *testing.T) {
+		t.Setenv("FCQS_NOTES_FILE", test.FullPath(test.LocationFile)+":"+"invalid_file")
+		setOSArgs(t, []string{"fcqs-cli"})
+
+		var buf bytes.Buffer
+		err := run(&buf)
+
+		assert.Error(t, err)
+		assert.EqualError(t, err, "notes file: open invalid_file: no such file or directory")
+	})
+}
+
 func TestRunWithURLFlag(t *testing.T) {
 	t.Setenv("FCQS_NOTES_FILE", test.FullPath(test.NotesFile))
 	setCommandLineFlag(t, "url")

--- a/fcqs_test.go
+++ b/fcqs_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -319,12 +318,7 @@ func TestNotesFileName(t *testing.T) {
 
 	t.Run("set files from environment variable", func(t *testing.T) {
 		expectedFileNames := []string{"test_file_1.md", "test_file_2.md", "test_file_3.md"}
-		sep := ":"
-		if runtime.GOOS == "windows" {
-			sep = ";"
-		}
-
-		t.Setenv("FCQS_NOTES_FILE", strings.Join(expectedFileNames, sep))
+		t.Setenv("FCQS_NOTES_FILE", strings.Join(expectedFileNames, test.FileSeparator()))
 
 		fileName, err := fcqs.NotesFileName()
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -180,6 +180,56 @@ func TestCmdNotesLocation(t *testing.T) {
 	assert.Empty(t, buf.stderr.String())
 }
 
+func TestCmdMultiFiles(t *testing.T) {
+	t.Setenv("FCQS_NOTES_FILE", LocationFile+":"+LocationExtraFile)
+
+	t.Run("show titles", func(t *testing.T) {
+		buf := &stdBuf{}
+		cmd := buf.newTestCmd()
+
+		err := cmd.Run()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "location test data\n5th Line\nother 5th Line\n9th Line\n", buf.stdout.String())
+		assert.Empty(t, buf.stderr.String())
+	})
+
+	t.Run("show contents", func(t *testing.T) {
+		buf := &stdBuf{}
+		cmd := buf.newTestCmd("9th Line")
+
+		err := cmd.Run()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "# 9th Line\n\nDo not chang the 9th line.\n", buf.stdout.String())
+		assert.Empty(t, buf.stderr.String())
+	})
+
+	t.Run("show location", func(t *testing.T) {
+		buf := &stdBuf{}
+		cmd := buf.newTestCmd("-l", "9th Line")
+
+		err := cmd.Run()
+
+		assert.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("%q 9\n", LocationExtraFile), buf.stdout.String())
+		assert.Empty(t, buf.stderr.String())
+	})
+
+	t.Run("file error", func(t *testing.T) {
+		t.Setenv("FCQS_NOTES_FILE", FullPath(LocationFile)+":"+"invalid_file")
+
+		buf := &stdBuf{}
+		cmd := buf.newTestCmd()
+
+		err := cmd.Run()
+
+		assert.Error(t, err)
+		assert.Equal(t, "notes file: open invalid_file: no such file or directory\n", buf.stderr.String())
+		assert.Empty(t, buf.stdout.String())
+	})
+}
+
 func TestUserHomeDirNotExists(t *testing.T) {
 	t.Setenv("FCQS_NOTES_FILE", "")
 	t.Setenv("HOME", "")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -181,7 +181,7 @@ func TestCmdNotesLocation(t *testing.T) {
 }
 
 func TestCmdMultiFiles(t *testing.T) {
-	t.Setenv("FCQS_NOTES_FILE", LocationFile+":"+LocationExtraFile)
+	t.Setenv("FCQS_NOTES_FILE", LocationFile+FileSeparator()+LocationExtraFile)
 
 	t.Run("show titles", func(t *testing.T) {
 		buf := &stdBuf{}
@@ -217,7 +217,7 @@ func TestCmdMultiFiles(t *testing.T) {
 	})
 
 	t.Run("file error", func(t *testing.T) {
-		t.Setenv("FCQS_NOTES_FILE", FullPath(LocationFile)+":"+"invalid_file")
+		t.Setenv("FCQS_NOTES_FILE", LocationFile+FileSeparator()+"invalid_file")
 
 		buf := &stdBuf{}
 		cmd := buf.newTestCmd()

--- a/test/test_helper.go
+++ b/test/test_helper.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	NotesFile      = "testdata/test_fcnotes.md"
-	ShellBlockFile = "testdata/test_shellblock.md"
-	LocationFile   = "testdata/test_location.md"
+	NotesFile         = "testdata/test_fcnotes.md"
+	ShellBlockFile    = "testdata/test_shellblock.md"
+	LocationFile      = "testdata/test_location.md"
+	LocationExtraFile = "testdata/test_location_extra.md"
 )
 
 // OpenTestNotesFile opens a test notes file.

--- a/test/test_helper.go
+++ b/test/test_helper.go
@@ -39,6 +39,15 @@ func FullPath(filename string) string {
 	return filepath.Join(path.Dir(thisFileName), filename)
 }
 
+func FileSeparator() string {
+	sep := ":"
+	if runtime.GOOS == "windows" {
+		sep = ";"
+	}
+
+	return sep
+}
+
 // ExpectedTitles returns the titles of the test notes.
 func ExpectedTitles() string {
 	return `title

--- a/test/testdata/test_location.md
+++ b/test/testdata/test_location.md
@@ -1,6 +1,6 @@
 # location test data
 
-This file is location test data
+This file is location test data.
 
 # 5th Line
 

--- a/test/testdata/test_location_extra.md
+++ b/test/testdata/test_location_extra.md
@@ -1,0 +1,11 @@
+# location test data
+
+This file is location extra test data.
+
+# other 5th Line
+
+Do not chang the 5th line.
+
+# 9th Line
+
+Do not chang the 9th line.


### PR DESCRIPTION
Add sypport for multi notes files. Users can set multiple files in the FCQS_NOTES_FILE environment variable separated by a separator.

```
export FCQS_NOTES_FILE=~/memo.md:~/other.md
```