### PR TITLE
Fix a bug that output many command line blocks with `-c` option

### DIFF
--- a/fcqs.go
+++ b/fcqs.go
@@ -144,6 +144,7 @@ func WriteFirstCmdLineBlock(w io.Writer, r io.Reader, title *value.Title) error 
 	}
 	scanner := newScanner(&buf)
 
+loop:
 	for scanner.Scan() {
 		line := scanner.Text()
 		fenceLine, isFenceLine := value.NewFenceLine(line)
@@ -156,7 +157,7 @@ func WriteFirstCmdLineBlock(w io.Writer, r io.Reader, title *value.Title) error 
 
 		case fenced:
 			if isFenceLine {
-				break
+				break loop
 			}
 			fmt.Fprintln(w, strings.TrimLeft(line, shellPrompt+" "))
 		}

--- a/fcqs_test.go
+++ b/fcqs_test.go
@@ -251,6 +251,19 @@ func TestWriteFirstCmdLine(t *testing.T) {
 			assert.Equal(t, expected[tc.output], buf.String())
 		})
 	}
+	t.Run("output only first command line block", func(t *testing.T) {
+		t.Parallel()
+
+		file := openTestNotesFile(t, test.NotesFile)
+		title, err := value.NewTitle("more command-line blocks")
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		err = fcqs.WriteFirstCmdLineBlock(&buf, file, title)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ls -l | nl\n", buf.String())
+	})
 
 	t.Run("scan error to seek contents", func(t *testing.T) {
 		t.Parallel()

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -59,7 +59,7 @@ func TestCmdSuccess(t *testing.T) {
 		},
 		{
 			title:   "with cmd flag and an arg",
-			options: []string{"-c", "command-line"},
+			options: []string{"-c", "more command-line blocks"},
 			stdout:  "ls -l | nl\n",
 		},
 		{

--- a/test/testdata/expected_titles.txt
+++ b/test/testdata/expected_titles.txt
@@ -12,3 +12,4 @@ Titles without a space after the # are not recognized
 URL
 command-line
 command-line with $
+more command-line blocks

--- a/test/testdata/test_fcnotes.md
+++ b/test/testdata/test_fcnotes.md
@@ -90,3 +90,12 @@ ls -l | nl
 $ date
 ```
 
+# more command-line blocks
+
+```sh
+ls -l | nl
+```
+
+```console
+$ date
+```


### PR DESCRIPTION
Fix a bug that output many command line blocks with -c option.

Fix #58 